### PR TITLE
API for initializing Package objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean-pyc:
 	find . -name '*~' -exec rm -f {} +
 
 lint:
-	flake8 web3
+	flake8 ethpm
 
 test:
 	py.test tests
@@ -31,9 +31,9 @@ test-all:
 	tox
 
 build-docs:
-	rm -f docs/web3.rst
+	rm -f docs/ethpm.rst
 	rm -f docs/modules.rst
-	sphinx-apidoc -o docs/ web3
+	sphinx-apidoc -o docs/ ethpm
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,7 @@ Then, the `OwnedPackage` can be instantiated with any `web3` intance.
 owned_package = OwnedPackage(web3)
 ```
 
-`Package` classes should be constructable from any of:
-
-* Local filesystem path to a lockfile
-* Lockfile URI
-* The parsed lockfile JSON
+A `Package` class can only be directly constructed from the parsed lockfile JSON. It can also be initialized with the lockfile's URI or the local filesystem path to a lockfile by using `Package.from_file(path)`.
 
 
 ## Contract Factories

--- a/ethpm/utils/package_validation.py
+++ b/ethpm/utils/package_validation.py
@@ -15,14 +15,6 @@ from ethpm.exceptions import ValidationError
 RELEASE_LOCKFILE_SCHEMA_PATH = os.path.join(ASSETS_DIR, 'release-lockfile.schema.v1.json')
 
 
-def load_package_data(package_id):
-    """
-    Load package json located in ASSETS_DIR.
-    """
-    with open(os.path.join(ASSETS_DIR, package_id)) as package:
-        return json.load(package)
-
-
 def _load_schema_data():
     with open(RELEASE_LOCKFILE_SCHEMA_PATH) as schema:
         return json.load(schema)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,22 +53,31 @@ LOCKFILE = {
   }
 }
 
+
 @pytest.fixture
-def lockfile_with_no_deployments(tmpdir):
+def valid_lockfile():
+    with open("ethpm/assets/validLockfile.json") as file_obj:
+        return json.load(file_obj)
+
+
+@pytest.fixture()
+def invalid_lockfile():
+    with open("ethpm/assets/invalidLockfile.json") as file_obj:
+        return json.load(file_obj)
+
+
+@pytest.fixture
+def lockfile_with_no_deployments():
     lockfile = copy.deepcopy(LOCKFILE)
     lockfile.pop("deployments")
-    f = tmpdir.join("lockfile.json")
-    f.write(json.dumps(lockfile))
-    return str(f)
+    return lockfile
 
 
 @pytest.fixture
 def lockfile_with_empty_deployments(tmpdir):
     lockfile = copy.deepcopy(LOCKFILE)
     lockfile["deployments"] = {}
-    f = tmpdir.join("lockfile.json")
-    f.write(json.dumps(lockfile))
-    return str(f)
+    return lockfile
 
 
 @pytest.fixture
@@ -87,9 +96,7 @@ def lockfile_with_matching_deployment(w3, tmpdir):
         "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c"
       }
     }
-    f = tmpdir.join("lockfile.json")
-    f.write(json.dumps(lockfile))
-    return str(f)
+    return lockfile
 
 
 @pytest.fixture
@@ -107,9 +114,7 @@ def lockfile_with_no_matching_deployments(w3, tmpdir):
         "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c"
       }
     }
-    f = tmpdir.join("lockfile.json")
-    f.write(json.dumps(lockfile))
-    return str(f)
+    return lockfile
 
 
 @pytest.fixture
@@ -124,36 +129,32 @@ def lockfile_with_multiple_matches(w3, tmpdir):
     lockfile = copy.deepcopy(LOCKFILE)
     lockfile['deployments'][block_uri] = {
         "SafeMathLib": {
-        "contract_type": "SafeMathLib",
-        "address": "0x8d2c532d7d211816a2807a411f947b211569b68c",
-        "transaction": "0xaceef751507a79c2dee6aa0e9d8f759aa24aab081f6dcf6835d792770541cb2b",
-        "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c"
-      }
+            "contract_type": "SafeMathLib",
+            "address": "0x8d2c532d7d211816a2807a411f947b211569b68c",
+            "transaction": "0xaceef751507a79c2dee6aa0e9d8f759aa24aab081f6dcf6835d792770541cb2b",
+            "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c"
+        }
     }
     lockfile['deployments'][second_block_uri] = {
-       "SafeMathLib": {
-        "contract_type": "SafeMathLib",
-        "address": "0x8d2c532d7d211816a2807a411f947b211569b68c",
-        "transaction": "0xaceef751507a79c2dee6aa0e9d8f759aa24aab081f6dcf6835d792770541cb2b",
-        "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c"
-      }
+        "SafeMathLib": {
+            "contract_type": "SafeMathLib",
+            "address": "0x8d2c532d7d211816a2807a411f947b211569b68c",
+            "transaction": "0xaceef751507a79c2dee6aa0e9d8f759aa24aab081f6dcf6835d792770541cb2b",
+            "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c"
+        }
     }
-    f = tmpdir.join("lockfile.json")
-    f.write(json.dumps(lockfile))
-    return str(f)
+    return lockfile
 
 
 @pytest.fixture
 def lockfile_with_conflicting_deployments(tmpdir):
     lockfile = copy.deepcopy(LOCKFILE)
     lockfile["deployments"]["blockchain://41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d/block/1e96de11320c83cca02e8b9caf3e489497e8e432befe5379f2f08599f8aecede"] = {
-      "WrongNameLib": {
-        "contract_type": "WrongNameLib",
-        "address": "0x8d2c532d7d211816a2807a411f947b211569b68c",
-        "transaction": "0xaceef751507a79c2dee6aa0e9d8f759aa24aab081f6dcf6835d792770541cb2b",
-        "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c"
-      }
+        "WrongNameLib": {
+            "contract_type": "WrongNameLib",
+            "address": "0x8d2c532d7d211816a2807a411f947b211569b68c",
+            "transaction": "0xaceef751507a79c2dee6aa0e9d8f759aa24aab081f6dcf6835d792770541cb2b",
+            "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c"
+        }
     }
-    f = tmpdir.join("lockfile.json")
-    f.write(json.dumps(lockfile))
-    return str(f)
+    return lockfile

--- a/tests/ethpm/test_contract_utils.py
+++ b/tests/ethpm/test_contract_utils.py
@@ -3,10 +3,10 @@ import pytest
 from ethpm.exceptions import ValidationError
 
 from ethpm.utils.contract import (
-  validate_minimal_contract_data_present,
-  validate_contract_name,
-  generate_contract_factory_kwargs,
-  validate_w3_instance,
+    validate_minimal_contract_data_present,
+    validate_contract_name,
+    generate_contract_factory_kwargs,
+    validate_w3_instance,
 )
 
 

--- a/tests/ethpm/test_package.py
+++ b/tests/ethpm/test_package.py
@@ -1,87 +1,41 @@
 import pytest
 
-import web3
-
 from ethpm.package import Package
 
 from ethpm.exceptions import ValidationError
 
 
-def test_ethpm_exists():
-    assert Package
-
-
 @pytest.fixture()
-def valid_package_id():
-    return "validLockfile.json"
+def package(valid_lockfile):
+    return Package(valid_lockfile)
 
 
-@pytest.fixture()
-def package_with_dependencies():
-    return "lockfileWithBuildDependencies.json"
-
-
-@pytest.fixture()
-def owned():
-    return "owned.json"
-
-
-@pytest.fixture()
-def invalid_package_id():
-    return "invalidLockfile.json"
-
-
-@pytest.fixture()
-def package(valid_package_id):
-    return Package(valid_package_id)
-
-
-def test_package_object_instantiates_with_valid_package_id(valid_package_id):
-    current_package = Package(valid_package_id)
-    assert current_package.package_id is valid_package_id
-    assert current_package.w3 is None
-    assert current_package.package_data['lockfile_version']
-    assert current_package.package_data['deployments']
-    assert current_package.package_data['contract_types']
-
-
-def test_package_object_fails_instantiation_with_invalid_package_id(invalid_package_id):
-    with pytest.raises(ValidationError):
-        Package(invalid_package_id)
-
-
-@pytest.mark.parametrize(
-    "invalid_path",
-    (
-        "./tests/ethpm/doesntExist.json",
-        "abcd",
-    )
-)
-def test_package_object_doesnt_instantiate_with_invalid_path(invalid_path):
-    with pytest.raises(ValidationError):
-        Package(invalid_path)
-
-
-def test_package_object_instantiates_with_a_web3_object(valid_package_id, w3):
-    current_package = Package(valid_package_id, w3)
+def test_package_object_instantiates_with_a_web3_object(valid_lockfile, w3):
+    current_package = Package(valid_lockfile, w3)
     assert current_package.w3 is w3
 
 
-def test_set_default_web3(valid_package_id, w3):
-    current_package = Package(valid_package_id)
+def test_set_default_web3(valid_lockfile, w3):
+    current_package = Package(valid_lockfile)
     current_package.set_default_w3(w3)
     assert current_package.w3 is w3
 
 
 def test_get_contract_type_with_unique_web3(package, w3):
     contract_factory = package.get_contract_type("Wallet", w3)
-    assert getattr(contract_factory, '__module__') == web3.contract.__name__
+    assert hasattr(contract_factory, 'address')
+    assert hasattr(contract_factory, 'abi')
+    assert hasattr(contract_factory, 'bytecode')
+    assert hasattr(contract_factory, 'bytecode_runtime')
 
 
 def test_get_contract_type_with_default_web3(package, w3):
     package.set_default_w3(w3)
     contract_factory = package.get_contract_type("Wallet")
-    assert getattr(contract_factory, '__module__') == web3.contract.__name__
+    assert hasattr(contract_factory, 'address')
+    assert hasattr(contract_factory, 'abi')
+    assert hasattr(contract_factory, 'bytecode')
+    assert hasattr(contract_factory, 'bytecode_runtime')
 
 
 @pytest.mark.parametrize("invalid_w3", ({"invalid": "w3"}))
@@ -100,29 +54,17 @@ def test_get_contract_type_throws_if_name_isnt_present(package, w3):
         assert package.get_contract_type("DoesNotExist", w3)
 
 
-def test_package_object_has_name_property(valid_package_id):
-    current_package = Package(valid_package_id)
+def test_package_object_has_name_property(valid_lockfile):
+    current_package = Package(valid_lockfile)
     assert current_package.name == "wallet"
 
 
-def test_package_object_has_version_property(valid_package_id):
-    current_package = Package(valid_package_id)
+def test_package_object_has_version_property(valid_lockfile):
+    current_package = Package(valid_lockfile)
     assert current_package.version == "1.0.0"
 
 
-def test_package_has_custom_str_repr(valid_package_id):
-    current_package = Package(valid_package_id)
+def test_package_has_custom_str_repr(valid_lockfile):
+    current_package = Package(valid_lockfile)
     assert current_package.__repr__() == "<Package wallet==1.0.0>"
-
-
-def test_package_cannot_be_initialized_with_build_dependencies(package_with_dependencies):
-    with pytest.raises(NotImplementedError):
-        Package(package_with_dependencies)
     
-
-def test_package_can_be_initialized_with_empty_dependency_key(valid_package_id):
-    assert Package(valid_package_id)
-
-
-def test_package_without_build_dependencies_can_be_initialized(owned):
-    assert Package(owned)

--- a/tests/ethpm/test_package_validation_utils.py
+++ b/tests/ethpm/test_package_validation_utils.py
@@ -3,7 +3,6 @@ import pytest
 from ethpm.exceptions import ValidationError
 
 from ethpm.utils.package_validation import (
-    load_package_data,
     validate_package_exists,
     validate_package_against_schema,
     validate_package_deployments,
@@ -20,37 +19,25 @@ def test_validate_package_exists_invalidates():
         validate_package_exists("DNE")
 
 
-def test_load_package():
-    package_data = load_package_data("validLockfile.json")
-    assert package_data['lockfile_version']
-    assert package_data['deployments']
-    assert package_data['contract_types']
+def test_validate_package_validates(valid_lockfile):
+    assert validate_package_against_schema(valid_lockfile) is None
 
 
-def test_validate_package_validates():
-    package_data = load_package_data("validLockfile.json")
-    assert validate_package_against_schema(package_data) is None
-
-
-def test_validate_package_invalidates():
-    package_data = load_package_data("invalidLockfile.json")
+def test_validate_package_invalidates(invalid_lockfile):
     with pytest.raises(ValidationError):
-        validate_package_against_schema(package_data)
+        validate_package_against_schema(invalid_lockfile)
 
 
 def test_validate_deployed_contracts_present_validates(lockfile_with_conflicting_deployments):
-    package_data = load_package_data(lockfile_with_conflicting_deployments)
     with pytest.raises(ValidationError):
-        validate_package_deployments(package_data)
+        validate_package_deployments(lockfile_with_conflicting_deployments)
 
 
 def test_validate_deployments(lockfile_with_matching_deployment):
-    package_data = load_package_data(lockfile_with_matching_deployment)
-    validate = validate_package_deployments(package_data)
+    validate = validate_package_deployments(lockfile_with_matching_deployment)
     assert validate is None
 
 
 def test_validate_deployed_contracts_pr(lockfile_with_no_deployments):
-    package_data = load_package_data(lockfile_with_no_deployments)
-    validate = validate_package_deployments(package_data)
+    validate = validate_package_deployments(lockfile_with_no_deployments)
     assert validate is None

--- a/tests/test_package_initialization.py
+++ b/tests/test_package_initialization.py
@@ -1,0 +1,98 @@
+import contextlib
+import os
+import json
+import pytest
+
+from ethpm import Package
+
+from ethpm.exceptions import ValidationError
+
+
+@contextlib.contextmanager
+def _generate_fixture_param(tmpdir, as_file_path, file_content):
+    temp_lockfile = tmpdir.mkdir('invalid').join('lockfile.json')
+    temp_lockfile.write(file_content)
+
+    if as_file_path:
+        yield str(temp_lockfile)
+    else:
+        with open(str(temp_lockfile)) as file_obj:
+            yield file_obj
+
+
+@pytest.fixture(params=[True, False])
+def valid_lockfile_from_path(tmpdir, request):
+    valid_lockfile = json.dumps({
+        "package_name": "foo",
+        "lockfile_version": "1",
+        "version": "1.0.0",
+    })
+    with _generate_fixture_param(tmpdir, request.param, valid_lockfile) as file_obj:
+        yield file_obj
+
+
+@pytest.fixture(params=[True, False])
+def invalid_lockfile_from_path(tmpdir, request):
+    invalid_lockfile = json.dumps({
+        "package_name": "foo",
+        "lockfile_version": "not a valid version",
+        "version": "1.0.0",
+    })
+    with _generate_fixture_param(tmpdir, request.param, invalid_lockfile) as file_obj_or_path:
+        yield file_obj_or_path
+
+
+@pytest.fixture(params=[True, False])
+def non_json_lockfile(tmpdir, request):
+    with _generate_fixture_param(tmpdir, request.param, 'This is invalid json') as file_obj_or_path:
+        yield file_obj_or_path
+
+
+def test_init_from_valid_lockfile_data():
+    minimal_lockfile = {
+        "package_name": "foo",
+        "lockfile_version": "1",
+        "version": "1.0.0",
+    }
+
+    Package(minimal_lockfile)
+
+
+def test_init_from_invalid_lockfile_data():
+    with pytest.raises(ValidationError):
+        Package({})
+
+
+def test_init_from_invalid_argument_type():
+    with pytest.raises(TypeError):
+        Package("not a lockfile")
+
+
+def test_from_file_fails_with_missing_filepath(tmpdir):
+    path = os.path.join(
+        str(tmpdir.mkdir('invalid')),
+        'lockfile.json',
+    )
+
+    assert not os.path.exists(path)
+    with pytest.raises(FileNotFoundError):
+        Package.from_file(path)
+
+
+def test_from_file_fails_with_non_json(non_json_lockfile):
+    with pytest.raises(json.JSONDecodeError):
+        Package.from_file(non_json_lockfile)
+
+
+def test_from_file_fails_with_invalid_lockfile(invalid_lockfile_from_path):
+    with pytest.raises(ValidationError):
+        Package.from_file(invalid_lockfile_from_path)
+
+
+def test_from_file_succeeds_with_valid_lockfile(valid_lockfile_from_path):
+    assert Package.from_file(valid_lockfile_from_path)
+
+
+def test_from_file_raises_type_error_with_invalid_param_type():
+    with pytest.raises(TypeError):
+        Package.from_file(1)


### PR DESCRIPTION
### What was wrong?

The package object currently expects a filepath to access its lockfile.

### How was it fixed?

This PR updates `Package` to take a lockfile object, and it provides a class method for converting lockfiles provided as paths into JSON objects (so they can be used to initialize Packages).

#### Cute Animal Picture

![Cute animal picture](https://media.giphy.com/media/1CrejqXxVZs9q/giphy.gif)

Closes #18 
